### PR TITLE
Fully resolve file path imports

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ var types = require('babel-types');
 var camel = require('lodash.camelcase');
 var kebab = require('lodash.kebabcase');
 var snake = require('lodash.snakecase');
+var pathLib = require('path');
 
 function barf(msg) {
     throw new Error('babel-plugin-transform-imports: ' + msg);
@@ -38,8 +39,16 @@ module.exports = function() {
                 // path.node.source is the library/module name, aka 'react-bootstrap'.
                 // path.node.specifiers is an array of ImportSpecifier | ImportDefaultSpecifier | ImportNamespaceSpecifier
 
-                if (path.node.source.value in state.opts) {
-                    var source = path.node.source.value;
+                var source = path.node.source.value;
+
+                if (!(source in state.opts) && source.match(/^\.{0,2}\//)) {
+                    source = pathLib.resolve(pathLib.join(
+                        source[0] === '/' ? '' : pathLib.dirname(state.file.opts.filename),
+                        source
+                    ));
+                }
+
+                if (source in state.opts) {
                     var opts = state.opts[source];
 
                     if (!opts.transform) {


### PR DESCRIPTION
This allows us to get the same behavior of this plugin for local
modules as well. eg, we have a local directory with lots of
components, and, for convenience, an index.js which just re-exports
all of the components.

Other local code can refer to these components by eg `import {A} from
'./components';`, so it'd be useful to use this plugin's
behavior. However, because the import source is a file path rather
than a library name, we currently cannot setup the transform
options (since the source could be './components', or '../components',
or '../../components', etc.). This PR solves that situation by fully
resolving the file paths.